### PR TITLE
fix katex options and build warnings

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,12 +6,10 @@ src = "src"
 title = "ZK Jargon Decoder"
 
 [preprocessor.katex]
-renderers = ["html"]
-
-[output.katex]
+after = ["links"]
 
 [output.html]
-curly-quotes = true
+smart-punctuation = true
 no-section-label = true
 git-repository-url = "https://github.com/nmohnblatt/zk-jargon-decoder"
 


### PR DESCRIPTION
Katex options in `book.toml` were outdated and caused build errors for recent versions of `mdbook-katex`