### PR TITLE
Acronyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ For detailed translation guidelines, please refer to our [TRANSLATE.md](TRANSLAT
 
 This work is shared under a Creative Commons Attribution-ShareAlike 4.0 International license. In brief, this allows others to use this work as long as they give attribution to this project, and share their own work under a similar license.
 
-ZK Jargon Decoder © 2022 by ZK Jargon Decoder contributors is licensed under CC BY-SA 4.0. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
+ZK Jargon Decoder © 2022-2025 by ZK Jargon Decoder contributors is licensed under CC BY-SA 4.0. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -4,6 +4,8 @@
 # Introduction to ZK Jargon
 - [What does it mean to *prove*?](./intro_to_zk/what_is_proving.md)
 - [Probabilistic and Interactive proofs](./intro_to_zk/interactive_proofs.md)
+# Acronyms
+- [List of Common Acronyms](./acronyms.md)
 # Definitions
 - [Algebraic Holographic Proof (AHP)](./definitions/algebraic_holographic_proof.md)
 - [Arithmetization](./definitions/arithmetization.md)

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -42,6 +42,7 @@ Below is a list of common acronyms, ordered alphabetically.
 - **FS transform -** [Fiat--SHamir transform](./definitions/fiat_shamir.md).
 
 ## G
+- **GC -** garbled circuit.
 - **GKR protocol -** Goldwasser--Kalai--Rothblum.
 
 ## H

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -52,6 +52,7 @@ Below is a list of common acronyms, ordered alphabetically.
 
 ## K
 - **KDF -** key-derivation function.
+- **KEM -** key encapsulation mechanism
 - **KZG commitment -** Kate--Zaverucha--Goldberg polynomial commitment scheme.
 
 ## L
@@ -70,21 +71,29 @@ Below is a list of common acronyms, ordered alphabetically.
 - **NIZK -** non-interactive zero-knowledge proof.
 - **NTT -** number-theoretic transform.
 
+## O
+- **oPRF -** oblivious pseudo-random function.
+
 ## P 
 - **PAIR -** pre-processed AIR. 
 - **PCD -** proof-carrying data.
 - **PCP -** probabilistically checkable proof. 
 - **PCS -** [polynomial commitment scheme](./definitions/polynomial_commitment.md). 
 - **PIOP -** polynomial interactive oracle proof. 
+- **PQC -** post-quantum cryptography.
 - **PRF -** pseudo-random function.
 - **PRG -** pseudo-random generator. 
 - **PVSS -** publicly verifiable secret sharing.
+
+## Q
+- **QAP -** quadratic arithmetic programme.
 
 ## R
 - **R1CS -** [rank-1 constraint system](./definitions/r1cs.md).
 - **RAP -** randomized AIR with pre-processing (equivalent to [PLONKish arithmetization](./definitions/plonkish_arithmetization.md)).
 - **ROM -** [random oracle model](./definitions/random_oracle.md).
 - **RS code -** Reed-Solomon code. 
+- **RTP -** real-time proving.
 
 ## S
 - **SIS -** short integer solution.

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -1,0 +1,107 @@
+# List of Common Acronyms
+
+Our jargon is full of acronyms.
+While they are useful to keep communications short and snappy, they can be quite opaque.
+Especially when they are hard to look up! 
+Below is a list of common acronyms, ordered alphabetically.
+
+## A
+- **AHP -** [algebraic holographic proof](./definitions/algebraic_holographic_proof.md).
+- **AIR -** algebraic intermediate representation.
+
+## B
+- **BCS transform-** Ben-Sasson--Chiesa--Spooner.
+- **BLS curves -** Barreto--Lynn--Scott.
+- **BLS signatures -** Boneh--Lynn--Sacham.
+- **BN curves -** Barreto--Naehrig.
+
+## C
+- **CCS -** customizable constraint system.
+- **CRS -** [common reference string](./definitions/common_reference_string.md).
+
+## D
+- **DKG -** distributed key generation.
+- **DLOG -** discrete logarithm.
+
+## E
+- **ECC -**
+    - elliptic curve cryptography.
+    - error-correcting codes.
+
+## F
+- **FFT -** [fast Fourier transform](./definitions/fast_fourier_transform.md).
+- **FHE -** [fully homomorphic encryption](./definitions/fhe.md).
+- **FRI -** fast Reed-Solomon IOPP of proximity.
+- **FS transform -** [Fiat--SHamir transform](./definitions/fiat_shamir.md).
+
+## G
+- **GKR protocol -** Goldwasser--Kalai--Rothblum.
+
+## H
+- **HE -** homomorphic encryption.
+- **HSM -** hardware security module.
+
+## I
+- **iO -** indistinguishability obfuscation.
+- **IOP -** interactive oracle proof. 
+- **IOPP -** interactive oracle proof of proximity.
+- **IP -** interactive proof.
+- **IVC -** incrementally verifiable computation.
+
+## K
+- **KDF -** key-derivation function.
+- **KZG commitment -** Kate--Zaverucha--Goldberg polynomial commitment scheme.
+
+## L
+- **LPC -** list polynomial commitment (scheme).
+- **LWE -** learning with error.
+
+## M
+- **MLE -** multilinear extension.
+- **MNT curves -** Miyaji--Nakabayashi--Takano.
+- **MPC -** multi-party computation.
+- **MSIS -** module short integer solution.
+
+## N
+- **NARG -** non-interactive argument.
+- **NARK -** non-interactive argument of knowledge.
+- **NIZK -** non-interactive zero-knowledge proof.
+- **NTT -** number-theoretic transform.
+
+## P 
+- **PAIR -** pre-processed AIR. 
+- **PCD -** proof-carrying data.
+- **PCP -** probabilistically checkable proof. 
+- **PCS -** [polynomial commitment scheme](./definitions/polynomial_commitment.md). 
+- **PIOP -** polynomial interactive oracle proof. 
+- **PRF -** pseudo-random function.
+- **PRG -** pseudo-random generator. 
+- **PVSS -** publicly verifiable secret sharing.
+
+## R
+- **R1CS -** [rank-1 constraint system](./definitions/r1cs.md).
+- **RAP -** randomized AIR with pre-processing (equivalent to [PLONKish arithmetization](./definitions/plonkish_arithmetization.md)).
+- **ROM -** [random oracle model](./definitions/random_oracle.md).
+- **RS code -** Reed-Solomon code. 
+
+## S
+- **SIS -** short integer solution.
+- **SNARG -** succinct non-interactive argument.
+- **SNARK -** succinct non-interactive argument of knowledge.
+- **SRS -** [structured reference string](./definitions/structured_reference_string.md).
+- **SS -** secret sharing.
+- **SSS -** Shamir secret sharing.
+- **STARK -** [scalable transparent argument of knowledge](./definitions/stark.md). 
+
+## V
+- **VDF -** verifiable delay function. 
+- **VSS -** verifiable secret sharing.
+
+## T
+- **TEE -** trusted execution environment.
+- **TFHE -** torus fully homomorphic encryption (not to be confused with threshold FHE).
+
+## Z
+- **ZK -** [zero-knowledge](./definitions/zero_knowledge_proof.md).
+- **zkVM -** [zero-knowledge virtual machine](./definitions/zkvm.md). 
+- **zkEVM -** zero-knowledge Ethereum virtual machine.

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -18,6 +18,7 @@ Below is a list of common acronyms, ordered alphabetically.
 
 ## C
 - **CCS -** customizable constraint system.
+- **coSNARK -** collaborative SNARK.
 - **CRS -** [common reference string](./definitions/common_reference_string.md).
 
 ## D

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -92,7 +92,7 @@ Below is a list of common acronyms, ordered alphabetically.
 - **PVSS -** publicly verifiable secret sharing.
 
 ## Q
-- **QAP -** quadratic arithmetic programme.
+- **QAP -** [quadratic arithmetic program](./definitions/quadratic_arithmetic_program.md).
 
 ## R
 - **R1CS -** [rank-1 constraint system](./definitions/r1cs.md).
@@ -133,3 +133,6 @@ Below is a list of common acronyms, ordered alphabetically.
 - **ZK -** [zero-knowledge](./definitions/zero_knowledge_proof.md).
 - **zkVM -** [zero-knowledge virtual machine](./definitions/zkvm.md). 
 - **zkEVM -** zero-knowledge Ethereum virtual machine.
+
+## Numbers
+- **2-PC -** two-party computation.

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -20,6 +20,8 @@ Below is a list of common acronyms, ordered alphabetically.
 - **CRS -** [common reference string](./definitions/common_reference_string.md).
 
 ## D
+- **DA -** data availability.
+- **DAS scheme -** data availability sampling scheme. 
 - **DKG -** distributed key generation.
 - **DLOG -** discrete logarithm.
 

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -89,6 +89,7 @@ Below is a list of common acronyms, ordered alphabetically.
 - **PCP -** probabilistically checkable proof. 
 - **PCS -** [polynomial commitment scheme](./definitions/polynomial_commitment.md). 
 - **PIOP -** polynomial interactive oracle proof. 
+- **PPOT -** perpetual powers of tau (trusted setup ceremony).
 - **PQC -** post-quantum cryptography.
 - **PRF -** pseudo-random function.
 - **PRG -** pseudo-random generator. 

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -32,6 +32,8 @@ Below is a list of common acronyms, ordered alphabetically.
 - **ECC -**
     - elliptic curve cryptography.
     - error-correcting codes.
+- **ECDSA -** elliptic curve digital signature algorithm.
+- **EdDSA -** Edwards-curve digital signature algorithm.
 
 ## F
 - **FFT -** [fast Fourier transform](./definitions/fast_fourier_transform.md).
@@ -100,6 +102,7 @@ Below is a list of common acronyms, ordered alphabetically.
 - **RAP -** randomized AIR with pre-processing (equivalent to [PLONKish arithmetization](./definitions/plonkish_arithmetization.md)).
 - **ROM -** [random oracle model](./definitions/random_oracle.md).
 - **RS code -** Reed-Solomon code. 
+- **RSA -** Rivest--Shamir--Adleman.
 - **RTP -** real-time proving.
 
 ## S
@@ -127,6 +130,7 @@ Below is a list of common acronyms, ordered alphabetically.
 - **WE -** [witness encryption](./definitions/witness_encryption.md).
 
 ## X
+- **X3DH -** extended triple Diffie Hellman (key agreement protocol).
 
 ## Y
 

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -89,7 +89,7 @@ Below is a list of common acronyms, ordered alphabetically.
 - **PCP -** probabilistically checkable proof. 
 - **PCS -** [polynomial commitment scheme](./definitions/polynomial_commitment.md). 
 - **PIOP -** polynomial interactive oracle proof. 
-- **PPOT -** perpetual powers of tau (trusted setup ceremony).
+- **PPOT -** [perpetual powers of tau](https://pse.dev/fr/projects/powers-of-tau) (trusted setup ceremony).
 - **PQC -** post-quantum cryptography.
 - **PRF -** pseudo-random function.
 - **PRG -** pseudo-random generator. 

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -10,6 +10,7 @@ Below is a list of common acronyms, ordered alphabetically.
 - **AIR -** algebraic intermediate representation.
 
 ## B
+- **BARG -** batch argument.
 - **BCS transform-** Ben-Sasson--Chiesa--Spooner.
 - **BLS curves -** Barreto--Lynn--Scott.
 - **BLS signatures -** Boneh--Lynn--Sacham.
@@ -21,7 +22,8 @@ Below is a list of common acronyms, ordered alphabetically.
 
 ## D
 - **DA -** data availability.
-- **DAS scheme -** data availability sampling scheme. 
+- **DAS scheme -** data availability sampling scheme.
+- **DEEP -** domain extension for the elimination of pretenders. 
 - **DKG -** distributed key generation.
 - **DLOG -** discrete logarithm.
 
@@ -48,6 +50,7 @@ Below is a list of common acronyms, ordered alphabetically.
 - **IOP -** interactive oracle proof. 
 - **IOPP -** interactive oracle proof of proximity.
 - **IP -** interactive proof.
+- **IPA -** inner-product argument.
 - **IVC -** incrementally verifiable computation.
 
 ## K
@@ -60,9 +63,10 @@ Below is a list of common acronyms, ordered alphabetically.
 - **LWE -** learning with error.
 
 ## M
+- **M31 -** the Mersenne prime $2^{31} - 1$.
 - **MLE -** multilinear extension.
 - **MNT curves -** Miyaji--Nakabayashi--Takano.
-- **MPC -** multi-party computation.
+- **MPC -** [multi-party computation](./definitions/mpc.md).
 - **MSIS -** module short integer solution.
 
 ## N
@@ -98,7 +102,7 @@ Below is a list of common acronyms, ordered alphabetically.
 ## S
 - **SIS -** short integer solution.
 - **SNARG -** succinct non-interactive argument.
-- **SNARK -** succinct non-interactive argument of knowledge.
+- **SNARK -** [succinct non-interactive argument of knowledge](./definitions/snark.md).
 - **SRS -** [structured reference string](./definitions/structured_reference_string.md).
 - **SS -** secret sharing.
 - **SSS -** Shamir secret sharing.

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -95,13 +95,13 @@ Below is a list of common acronyms, ordered alphabetically.
 - **SSS -** Shamir secret sharing.
 - **STARK -** [scalable transparent argument of knowledge](./definitions/stark.md). 
 
-## V
-- **VDF -** verifiable delay function. 
-- **VSS -** verifiable secret sharing.
-
 ## T
 - **TEE -** trusted execution environment.
 - **TFHE -** torus fully homomorphic encryption (not to be confused with threshold FHE).
+
+## V
+- **VDF -** verifiable delay function. 
+- **VSS -** verifiable secret sharing.
 
 ## Z
 - **ZK -** [zero-knowledge](./definitions/zero_knowledge_proof.md).

--- a/src/acronyms.md
+++ b/src/acronyms.md
@@ -53,6 +53,8 @@ Below is a list of common acronyms, ordered alphabetically.
 - **IPA -** inner-product argument.
 - **IVC -** incrementally verifiable computation.
 
+## J
+
 ## K
 - **KDF -** key-derivation function.
 - **KEM -** key encapsulation mechanism
@@ -112,9 +114,20 @@ Below is a list of common acronyms, ordered alphabetically.
 - **TEE -** trusted execution environment.
 - **TFHE -** torus fully homomorphic encryption (not to be confused with threshold FHE).
 
+
+## U
+- **UC -** universal composability.
+
 ## V
 - **VDF -** verifiable delay function. 
 - **VSS -** verifiable secret sharing.
+
+## W
+- **WE -** [witness encryption](./definitions/witness_encryption.md).
+
+## X
+
+## Y
 
 ## Z
 - **ZK -** [zero-knowledge](./definitions/zero_knowledge_proof.md).

--- a/src/definitions/base_field.md
+++ b/src/definitions/base_field.md
@@ -1,6 +1,8 @@
 # Base Field
 > *Elliptic Curve Cryptography*. The finite field from which coordinates $(x, y)$ of an elliptic curve point are chosen.
 
+---
+
 *⚠️ Prerequisites: [Finite fields](https://zcash.github.io/halo2/background/fields.html).*
 
 See [Elliptic Curve](./elliptic_curve.md).

--- a/src/definitions/elliptic_curve.md
+++ b/src/definitions/elliptic_curve.md
@@ -1,6 +1,8 @@
 # Elliptic Curve
 > A set of coordinate pairs $(x,y)$ that satisfy the equation $y^2 = x^3 + ax + b $.
 
+---
+
 *⚠️ Prerequisites: [Finite fields](https://zcash.github.io/halo2/background/fields.html).*
 
 An elliptic curve is defined as the set of all coordinate pairs $(x, y)$ such that:

--- a/src/definitions/scalar_field.md
+++ b/src/definitions/scalar_field.md
@@ -2,6 +2,8 @@
 
 > *Elliptic Curve Cryptography*. The finite field defined by counting the number of repeated applications of the group operation (i.e. point addition).
 
+---
+
 *⚠️ Prerequisites: [Finite fields](https://zcash.github.io/halo2/background/fields.html).*
 
 See [Elliptic Curve](./elliptic_curve.md).

--- a/src/definitions/witness.md
+++ b/src/definitions/witness.md
@@ -1,6 +1,8 @@
 # Witness
 > *(Of a general purpose [SNARK](./snark.md))*. All the [circuit](./circuit.md) variables that the verifier does not see: the prover's private inputs and all the intermediate values computed in the circuit.
 
+---
+
 In a general purpose [SNARK](./snark.md), we call the **witness** the collection of values that the verifier does not read; either because they are private to the prover, or because they are too long to satisfy the [succinctness](./snark.md#snarks) property.
 
 Consider the following example:  

--- a/src/definitions/zero_knowledge_proof.md
+++ b/src/definitions/zero_knowledge_proof.md
@@ -2,6 +2,8 @@
 
 > A proof that reveals no more information than the validity of the statement it supports.
 
+---
+
 A proof is said to be "zero-knowledge" if it does not reveal *any* information beyond the fact that a statement is `TRUE`.
 
 Zero-knowledge proofs provide **privacy** for the prover.

--- a/src/foreword.md
+++ b/src/foreword.md
@@ -12,4 +12,4 @@ This project is still work in progress, participation and suggestions are always
 
 ## License
 
-ZK Jargon Decoder © 2022 by ZK Jargon Decoder contributors is licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+ZK Jargon Decoder © 2022-2025 by ZK Jargon Decoder contributors is licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)


### PR DESCRIPTION
Add a dedicated page to decode acronyms. Where possible acronyms are linked to a definition in the ZK Jargon Decoder.